### PR TITLE
add environment label for dashboard templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@ This repository contains the pinned version of [Grafana Alloy] as used in all
 cloud environments. In order to update the Docker image, prepare all desired
 changes within the `main` branch and create a Github release for the Alloy
 version. The responsible [Github Action] will then build and push the image to
-the correct [Amazon ECR] upon tag creation.
+the correct [Amazon ECR] upon tag creation. The following environment variables
+are required for running the Alloy container.
+
+- `ENVIRONMENT` - the environment name of the scraped deployment infrastructure
+- `GRAFANA_CLOUD_API_KEY` - the API key of the Grafana Cloud metrics backend
+- `PROMETHEUS_REMOTE_WRITE_URL` - the URL of the Grafana Cloud metrics backend
+- `PROMETHEUS_USERNAME` - the basic auth username of the Grafana Cloud metrics backend
+- `SERVER_DISCOVERY_HOST` - the host name of the DNS discovery service for the server component
+- `SERVER_DISCOVERY_PORT` - the port number of the server components
 
 [Amazon ECR]: https://docs.aws.amazon.com/ecr
 [Github Action]: .github/workflows/docker-release.yaml

--- a/config.alloy
+++ b/config.alloy
@@ -1,4 +1,35 @@
-prometheus.remote_write "default" {
+discovery.dns "server" {
+  type = "A"
+  name = sys.env("SERVER_DISCOVERY_HOST")
+  port = sys.env("SERVER_DISCOVERY_PORT")
+}
+
+# The server component is resolved via DNS discovery. All IP addresses resolving
+# for the given discovery host will be scraped. All metrics are forwarded to the
+# relabelling processor below.
+prometheus.scrape "splits_server" {
+  targets      = discovery.dns.server.targets
+  metrics_path  = "/metrics"
+  job_name      = "splits_server"
+  forward_to  = [prometheus.relabel.set_env.receiver]
+}
+
+# This relabelling processor adds the "env" label to all metrics. Any metrics
+# having the "invalid" default value assigned must be fixed by injecting the
+# desired ENVIRONMENT env var into the Alloy process. All metrics are forwarded
+# to the remote write processor below.
+prometheus.relabel "set_env" {
+  rule {
+    action       = "replace"
+    target_label = "env"
+    replacement  = coalesce(sys.env("ENVIRONMENT"), "invalid")
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+}
+
+# This remote write processor pushes all metrics to Grafana Cloud. The metrics
+# pipeline ends here.
+prometheus.remote_write "grafana_cloud" {
   endpoint {
     url = sys.env("PROMETHEUS_REMOTE_WRITE_URL")
     basic_auth {
@@ -6,17 +37,4 @@ prometheus.remote_write "default" {
       password = sys.env("GRAFANA_CLOUD_API_KEY")
     }
   }
-}
-
-discovery.dns "server" {
-  type = "A"
-  name = sys.env("SERVER_DISCOVERY_HOST")
-  port = sys.env("SERVER_DISCOVERY_PORT")
-}
-
-prometheus.scrape "server" {
-  targets      = discovery.dns.server.targets
-  metrics_path = "/metrics"
-  job_name     = "server"
-  forward_to   = [ prometheus.remote_write.default.receiver ]
 }


### PR DESCRIPTION
We are adding the `env` label to all of our metrics here so that we can differentiate between `dev`, `test`, `stage` and `prod`. This label enables us to create templates for our dashboards, so that we can use the same dashboards easily for all environments alike. Template variables will give us dropdown buttons for dashboards, which we can use to select environments to look at.

<img width="429" alt="Screenshot 2025-05-12 at 14 30 44" src="https://github.com/user-attachments/assets/008c14eb-f773-4c49-8129-a7cbc92aeabb" />
