### PR TITLE
fix shell command injection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM grafana/alloy:v1.8.3
 COPY config.alloy /etc/alloy/config.alloy
-CMD run --server.http.listen-addr=0.0.0.0:12345 /etc/alloy/config.alloy
+CMD ["run", "--server.http.listen-addr=0.0.0.0:12345", "/etc/alloy/config.alloy"]


### PR DESCRIPTION
The `CMD` instruction was interpreted with an injected shell command because of its shell argument definition.

```
["/bin/sh", "-c", "run --server.http.listen-addr=..."]
```

Defining JSON command args fixes this issue.

```
 1 warning found (use docker --debug to expand):
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 3)
```

The unintended behaviour was for the Alloy container to fail with this message.

```
Error: unknown command "/bin/sh" for "/bin/alloy"
Run '/bin/alloy --help' for usage.
```