### PR TITLE
rewrite legacy env labels to match new convention

### DIFF
--- a/config.alloy
+++ b/config.alloy
@@ -24,6 +24,35 @@ prometheus.relabel "set_env" {
     target_label = "env"
     replacement  = coalesce(sys.env("ENVIRONMENT"), "invalid")
   }
+
+  forward_to  = [prometheus.relabel.fix_env.receiver]
+}
+
+// This relabelling processor rewrites some values of the "env" label to match
+// our environment conventions. NOTE that this processor should be temporary.
+// As soon as those environment conventions are streamlined across the stack, we
+// can drop the rules below.
+//
+//     dev     ->    testing
+//     beta    ->    staging
+//
+prometheus.relabel "fix_env" {
+  rule {
+    action = "replace"
+    source_labels = ["env"]
+    regex = "dev"
+    replacement = "testing"
+    target_label = "env"
+  }
+
+  rule {
+    action = "replace"
+    source_labels = ["env"]
+    regex = "beta"
+    replacement = "staging"
+    target_label = "env"
+  }
+
   forward_to = [prometheus.remote_write.grafana_cloud.receiver]
 }
 


### PR DESCRIPTION
With that change we rewrite `dev` to `testing` and `beta` to `staging`. I tested this with our Docker compose setup and verified the processing using the Alloy dashboard and the results in Grafana Cloud.