### PR TITLE
copy config dir in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM grafana/alloy:v1.8.3
-COPY config.alloy /etc/alloy/config.alloy
-CMD ["run", "--server.http.listen-addr=0.0.0.0:12345", "/etc/alloy/config.alloy"]
+COPY config/ /etc/alloy/
+CMD ["run", "--server.http.listen-addr=0.0.0.0:12345", "/etc/alloy/"]


### PR DESCRIPTION
The prior change forgot to handle the updated config structure in the Dockerfile. Fixing this here.