### PR TITLE
filter cloudwatch discovery by environment tags

### DIFF
--- a/config/003_discovery_cloudwatch.alloy
+++ b/config/003_discovery_cloudwatch.alloy
@@ -5,6 +5,9 @@ prometheus.exporter.cloudwatch "ecs_service" {
 		type                        = "AWS/ECS"
 		regions                     = [sys.env("AWS_REGION")]
 		dimension_name_requirements = ["ClusterName", "ServiceName"]
+		search_tags                 = {
+			"environment" = sys.env("ENVIRONMENT"),
+		}
 
 		metric {
 			name       = "CPUUtilization"


### PR DESCRIPTION
Alloy discovers all ECS clusters at the moment. We added the `environment` tags in AWS and want to try `search_tags` to see if this helps to specify the time series relevant per environment. E.g. in `testing` we don't want to see any `production` metrics.

<img width="1215" alt="Screenshot 2025-05-30 at 15 50 25" src="https://github.com/user-attachments/assets/71e09c8f-41f4-4d37-9db3-56ac85993844" />
