### PR TITLE
scrape RDS specific instance metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,28 @@ Alloy container.
 - `SERVER_DISCOVERY_HOST` - the host name of the DNS discovery service for the server component
 - `SERVER_DISCOVERY_PORT` - the port number of the server components
 
+### Discovery
+
+We are using the [CloudWatch Exporter] for metrics discovery of managed AWS
+services like ECS containers and RDS instances. Note that it is best practice to
+filter for AWS resource tags, e.g. `environment`, so that we can process metrics
+for the environment that those metrics are associated with. Also note that this
+requires the respective AWS resources to be tagged accordingly. Using the AWS
+CLI command below we can query the available metrics names and dimension
+requirements. This helps to identify the metrics that we could be interested to
+scrape.
+
+```
+aws cloudwatch list-metrics --namespace "AWS/RDS" --region us-west-2
+```
+
+Piping the results from the above CLI command into `jq` may help to filter for
+the metrics and their respective dimensions that we are interested in to scrape.
+
+```
+jq '[.Metrics[] | select(.Dimensions[]? | select(.Name == "Role" and .Value == "READER"))]'
+```
+
 ### Releases
 
 In order to update the Docker image, prepare all desired changes within the
@@ -61,3 +83,4 @@ to be [installed] locally in order to work properly.
 [Semver Format]: https://semver.org
 [VS Code Extension]: https://github.com/grafana/vscode-alloy
 [installed]: https://grafana.com/docs/alloy/latest/set-up/install
+[CloudWatch Exporter]: https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.cloudwatch

--- a/config/002_scrape.alloy
+++ b/config/002_scrape.alloy
@@ -7,6 +7,15 @@ prometheus.scrape "ecs_service" {
 	forward_to = [prometheus.relabel.set_env.receiver]
 }
 
+// The RDS instances are resolved via CloudWatch discovery. All instances
+// resolving for the given discovery type will be scraped. All metrics are
+// forwarded to the relabelling processor below.
+prometheus.scrape "rds_instance" {
+	targets    = prometheus.exporter.cloudwatch.rds_instance.targets
+	job_name   = "rds_instance"
+	forward_to = [prometheus.relabel.set_env.receiver]
+}
+
 // The worker component is resolved via DNS discovery. All IP addresses
 // resolving for the given discovery host will be scraped. All metrics are
 // forwarded to the relabelling processor below.

--- a/config/003_discovery_cloudwatch.alloy
+++ b/config/003_discovery_cloudwatch.alloy
@@ -22,3 +22,64 @@ prometheus.exporter.cloudwatch "ecs_service" {
 		}
 	}
 }
+
+prometheus.exporter.cloudwatch "rds_instance" {
+	sts_region = sys.env("AWS_REGION")
+
+	discovery {
+		type                        = "AWS/RDS"
+		regions                     = [sys.env("AWS_REGION")]
+		dimension_name_requirements = ["EngineName"]
+		search_tags                 = {
+			"environment" = sys.env("ENVIRONMENT"),
+		}
+
+		metric {
+			name       = "CPUUtilization"
+			statistics = ["Average", "Maximum"]
+			period     = "5m"
+		}
+
+		metric {
+			name       = "FreeableMemory"
+			statistics = ["Average", "Maximum"]
+			period     = "5m"
+		}
+
+		metric {
+			name       = "ReadLatency"
+			statistics = ["Average", "Maximum"]
+			period     = "5m"
+		}
+
+		metric {
+			name       = "WriteLatency"
+			statistics = ["Average", "Maximum"]
+			period     = "5m"
+		}
+
+		metric {
+			name       = "ReadThroughput"
+			statistics = ["Average", "Maximum"]
+			period     = "5m"
+		}
+
+		metric {
+			name       = "WriteThroughput"
+			statistics = ["Average", "Maximum"]
+			period     = "5m"
+		}
+
+		metric {
+			name       = "DatabaseConnections"
+			statistics = ["Average", "Maximum"]
+			period     = "5m"
+		}
+
+		metric {
+			name       = "FreeStorageSpace"
+			statistics = ["Average", "Maximum"]
+			period     = "5m"
+		}
+	}
+}


### PR DESCRIPTION
Towards https://linear.app/splits/issue/PE-4009/instrument-postgres. We are defining the RDS discovery job and scrape its metrics accordingly.

Here we also add some documentation about Alloy's discovery feature.