### PR TITLE
separate relabelling chains to prevent undesired label overwrites

### DIFF
--- a/config/001_relabel.alloy
+++ b/config/001_relabel.alloy
@@ -9,35 +9,7 @@ prometheus.relabel "set_env" {
 		replacement  = coalesce(sys.env("ENVIRONMENT"), "invalid")
 	}
 
-	forward_to = [prometheus.relabel.fix_env.receiver]
-}
-
-// This relabelling processor rewrites some values of the "env" label to match
-// our environment conventions. NOTE that this processor should be temporary.
-// As soon as those environment conventions are streamlined across the stack, we
-// can drop the rules below.
-//
-//     dev     ->    testing
-//     beta    ->    staging
-//
-prometheus.relabel "fix_env" {
-	rule {
-		action        = "replace"
-		source_labels = ["env"]
-		regex         = "dev"
-		replacement   = "testing"
-		target_label  = "env"
-	}
-
-	rule {
-		action        = "replace"
-		source_labels = ["env"]
-		regex         = "beta"
-		replacement   = "staging"
-		target_label  = "env"
-	}
-
-	forward_to = [prometheus.relabel.remove_labels.receiver]
+	forward_to = [prometheus.remote_write.grafana_cloud.receiver]
 }
 
 // Remove extraneous labels that may be added by certain exporters/jobs. E.g.
@@ -71,7 +43,7 @@ prometheus.relabel "remove_labels" {
 		target_label  = "region"
 	}
 
-	forward_to = [prometheus.relabel.create_labels.receiver]
+	forward_to = [prometheus.relabel.set_env.receiver]
 }
 
 // Create labels based on regular expressions to make it easier for certain
@@ -118,5 +90,5 @@ prometheus.relabel "create_labels" {
 		target_label  = "service"
 	}
 
-	forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+	forward_to = [prometheus.relabel.remove_labels.receiver]
 }

--- a/config/002_scrape.alloy
+++ b/config/002_scrape.alloy
@@ -1,24 +1,33 @@
 // The ECS containers are resolved via CloudWatch discovery. All containers
 // resolving for the given discovery type will be scraped. All metrics are
-// forwarded to the relabelling processor below.
+// forwarded to the relabelling processors as shown below.
+//
+//     create_labels  ->  remove_labels  ->  set_env  ->  grafana_cloud
+//
 prometheus.scrape "ecs_service" {
 	targets    = prometheus.exporter.cloudwatch.ecs_service.targets
 	job_name   = "ecs_service"
-	forward_to = [prometheus.relabel.set_env.receiver]
+	forward_to = [prometheus.relabel.create_labels.receiver]
 }
 
 // The RDS instances are resolved via CloudWatch discovery. All instances
 // resolving for the given discovery type will be scraped. All metrics are
-// forwarded to the relabelling processor below.
+// forwarded to the relabelling processors as shown below.
+//
+//     remove_labels  ->  set_env  ->  grafana_cloud
+//
 prometheus.scrape "rds_instance" {
 	targets    = prometheus.exporter.cloudwatch.rds_instance.targets
 	job_name   = "rds_instance"
-	forward_to = [prometheus.relabel.set_env.receiver]
+	forward_to = [prometheus.relabel.remove_labels.receiver]
 }
 
 // The worker component is resolved via DNS discovery. All IP addresses
 // resolving for the given discovery host will be scraped. All metrics are
-// forwarded to the relabelling processor below.
+// forwarded to the relabelling processors as shown below.
+//
+//     set_env  ->  grafana_cloud
+//
 prometheus.scrape "splits_worker" {
 	targets      = discovery.dns.worker.targets
 	metrics_path = "/metrics"
@@ -28,7 +37,10 @@ prometheus.scrape "splits_worker" {
 
 // The server component is resolved via DNS discovery. All IP addresses
 // resolving for the given discovery host will be scraped. All metrics are
-// forwarded to the relabelling processor below.
+// forwarded to the relabelling processors as shown below.
+//
+//     set_env  ->  grafana_cloud
+//
 prometheus.scrape "splits_server" {
 	targets      = discovery.dns.server.targets
 	metrics_path = "/metrics"


### PR DESCRIPTION
When we introduced the scraping of ECS container metrics via CloudWatch, we added certain relabelling processor in order to work with some unfortunate naming coming from our CloudFormation resources. When we then started scraping RDS instance metrics, those ECS relabelling processors affected RDS metrics. This change here tries to restructure the processor chains in order to prevent those processing conflict. See the code comments for the new chain arrangement.

Also note that we removed the relabelling processor that intended to fix our environment naming convention. This should be safe to remove since we migrated to use our environment naming convention in CloudFormation. This fixing step is still present in our **Docker Compose** setup though.