### PR TITLE
use the DBInstanceIdentifier dimension for RDS metrics

### DIFF
--- a/config/001_relabel.alloy
+++ b/config/001_relabel.alloy
@@ -15,7 +15,7 @@ prometheus.relabel "set_env" {
 // Remove extraneous labels that may be added by certain exporters/jobs. E.g.
 // CloudWatch specific labels may increase label cardinality for no reason, so
 // we try to reduce costs.
-prometheus.relabel "remove_labels" {
+prometheus.relabel "delete_cloudwatch_labels" {
 	rule {
 		action        = "replace"
 		source_labels = ["job", "name"]
@@ -46,10 +46,10 @@ prometheus.relabel "remove_labels" {
 	forward_to = [prometheus.relabel.set_env.receiver]
 }
 
-// Create labels based on regular expressions to make it easier for certain
-// dashboard queries. E.g. provide consistent service labels for our software
-// components: server, worker, alloy, etc.
-prometheus.relabel "create_labels" {
+// Create labels based on ECS dimensions to make it easier for certain dashboard
+// queries. E.g. provide consistent service labels for our software components:
+// server, worker, alloy, etc.
+prometheus.relabel "create_ecs_labels" {
 	rule {
 		action        = "replace"
 		source_labels = ["dimension_ServiceName"]
@@ -90,5 +90,21 @@ prometheus.relabel "create_labels" {
 		target_label  = "service"
 	}
 
-	forward_to = [prometheus.relabel.remove_labels.receiver]
+	forward_to = [prometheus.relabel.delete_cloudwatch_labels.receiver]
+}
+
+// Create labels based on RDS dimensions to make it easier for certain dashboard
+// queries. E.g. provide consistent service labels for our software components.
+// Since there is only one logical database for the server at the moment, we
+// only apply one service label.
+prometheus.relabel "create_rds_labels" {
+	rule {
+		action        = "replace"
+		source_labels = ["dimension_DBInstanceIdentifier"]
+		regex         = ".*"
+		replacement   = "server"
+		target_label  = "service"
+	}
+
+	forward_to = [prometheus.relabel.delete_cloudwatch_labels.receiver]
 }

--- a/config/002_scrape.alloy
+++ b/config/002_scrape.alloy
@@ -2,24 +2,24 @@
 // resolving for the given discovery type will be scraped. All metrics are
 // forwarded to the relabelling processors as shown below.
 //
-//     create_labels  ->  remove_labels  ->  set_env  ->  grafana_cloud
+//     create_ecs_labels  ->  delete_cloudwatch_labels  ->  set_env  ->  grafana_cloud
 //
 prometheus.scrape "ecs_service" {
 	targets    = prometheus.exporter.cloudwatch.ecs_service.targets
 	job_name   = "ecs_service"
-	forward_to = [prometheus.relabel.create_labels.receiver]
+	forward_to = [prometheus.relabel.create_ecs_labels.receiver]
 }
 
 // The RDS instances are resolved via CloudWatch discovery. All instances
 // resolving for the given discovery type will be scraped. All metrics are
 // forwarded to the relabelling processors as shown below.
 //
-//     remove_labels  ->  set_env  ->  grafana_cloud
+//     create_rds_labels  ->  delete_cloudwatch_labels  ->  set_env  ->  grafana_cloud
 //
 prometheus.scrape "rds_instance" {
 	targets    = prometheus.exporter.cloudwatch.rds_instance.targets
 	job_name   = "rds_instance"
-	forward_to = [prometheus.relabel.remove_labels.receiver]
+	forward_to = [prometheus.relabel.create_rds_labels.receiver]
 }
 
 // The worker component is resolved via DNS discovery. All IP addresses

--- a/config/003_discovery_cloudwatch.alloy
+++ b/config/003_discovery_cloudwatch.alloy
@@ -29,7 +29,7 @@ prometheus.exporter.cloudwatch "rds_instance" {
 	discovery {
 		type                        = "AWS/RDS"
 		regions                     = [sys.env("AWS_REGION")]
-		dimension_name_requirements = ["EngineName"]
+		dimension_name_requirements = ["DBInstanceIdentifier"]
 		search_tags                 = {
 			"environment" = sys.env("ENVIRONMENT"),
 		}


### PR DESCRIPTION
I noticed that we are scraping the same metrics for all environments, that is to say, the same metric values occurred in Grafana Cloud for all environments for the RDS instances. It can't be right that RDS produces the same metrics in all environments. Something has to be wrong here. My guess is that the CloudWatch dimensions for the RDS metrics were wrong. I have no idea what the engine-specific dimensions are good for now. I want to try the DB instance dimensions and see if we can scrape the correct metrics for the database instances across environments using `DBInstanceIdentifier`.

This issue became only visible when I deployed to multiple environments. I don't know how I could have caught this beforehand.