### PR TITLE
backup first recording rule for server slo

### DIFF
--- a/recording_rules/production_slo_server_usability.md
+++ b/recording_rules/production_slo_server_usability.md
@@ -1,0 +1,55 @@
+```yaml
+# Calculate the SLO for the server component in the production environment. The
+# basis of the SLO are all successful requests as specified in the docs. The
+# error budget taking away from the SLO is represented by requests responding
+# with failed status codes, and requests that take too long to respond. We
+# multiply the resulting ratio by 100, because the SLO is represented as
+# percent.
+#
+#     100 * ( status code SLO - latency SLO )
+#
+#     https://www.notion.so/splits/Service-Level-Objectives-208f7c3c8eff80bf9efcf1b1b9d4b105?source=copy_link#208f7c3c8eff8096af5efe11b5d682df
+#
+100 * (
+    # Calculate the average ratio of successful requests, by status code, over a
+    # 24 hour rolling window. The resulting ratio is the basis of the SLO. The
+    # latency query below is taking away from this basis.
+    #
+    #     successful requests | 0
+    #     -----------------------
+    #         all requests | 1
+    #
+    avg_over_time(
+        (
+            (sum(rate(http_request_duration_seconds_count{job="splits_server", env="production", middleware="root", route!~"/api/admin/*", code=~"2..|3..|404"}[5m])) OR vector(0))
+            /
+            (sum(rate(http_request_duration_seconds_count{job="splits_server", env="production", middleware="root", route!~"/api/admin/*", code!=""}[5m])) OR vector(1))
+        )[1d:]
+    )
+
+    -
+
+    # Calculate the average ratio of slow requests, over a 24 hour rolling
+    # window. The resulting error ratio is taking away from the SLO basis above.
+    #
+    #     all latencies - 500ms latencies
+    #     -------------------------------
+    #              all latencies
+    #
+    avg_over_time(
+        (
+            (
+                sum(rate(http_request_duration_seconds_bucket{job="splits_server", env="production", middleware="root", route!~"/api/admin/*", le="+Inf"}[5m]))
+                -
+                sum(rate(http_request_duration_seconds_bucket{job="splits_server", env="production", middleware="root", route!~"/api/admin/*", le="0.5"}[5m]))
+            )
+
+            /
+
+            (
+                sum(rate(http_request_duration_seconds_bucket{job="splits_server", env="production", middleware="root", route!~"/api/admin/*", le="+Inf"}[5m]))
+            )
+        )[1d:]
+    )
+)
+```


### PR DESCRIPTION
I started playing around with recording rules because our server dashboard is already getting slow because of the Usability SLO. It turns out we cannot configure recording rules in Alloy. We have to run a Prometheus instance or use managed recording rules in Grafana Cloud. I chose the latter. Now I want to make sure we have our recording rules backed up, so I just put it here. You can already use the output metric `production_slo_server_usability` as you can see in the explorer. In a week we can replace the monster query that we are using in the Usability graph with this dedicated timeseries. I used a markdown file with code block syntax highlighting because there is no good file extension and syntax support for `promql` at the moment.

<img width="1480" alt="Screenshot 2025-06-05 at 17 34 15" src="https://github.com/user-attachments/assets/6a25cfeb-c067-4b1e-bd64-2a802d3d29c2" />
