### PR TITLE
Revert "scrape aws codepipeline duration"

### DIFF
--- a/config/001_relabel.alloy
+++ b/config/001_relabel.alloy
@@ -46,22 +46,6 @@ prometheus.relabel "delete_cloudwatch_labels" {
 	forward_to = [prometheus.relabel.set_env.receiver]
 }
 
-// Create labels based on CodePipeline dimensions to make it easier for certain
-// dashboard queries. E.g. provide consistent service labels for our software
-// components. Since there is only one pipeline for the server at the moment, we
-// only apply one service label.
-prometheus.relabel "create_acp_labels" {
-	rule {
-		action        = "replace"
-		source_labels = ["dimension_Pipeline"]
-		regex         = ".*"
-		replacement   = "server"
-		target_label  = "service"
-	}
-
-	forward_to = [prometheus.relabel.delete_cloudwatch_labels.receiver]
-}
-
 // Create labels based on ECS dimensions to make it easier for certain dashboard
 // queries. E.g. provide consistent service labels for our software components:
 // server, worker, alloy, etc.

--- a/config/002_scrape.alloy
+++ b/config/002_scrape.alloy
@@ -1,15 +1,3 @@
-// The code pipelines are resolved via CloudWatch discovery. All code pipelines
-// resolving for the given discovery type will be scraped. All metrics are
-// forwarded to the relabelling processors as shown below.
-//
-//     create_acp_labels  ->  delete_cloudwatch_labels  ->  set_env  ->  grafana_cloud
-//
-prometheus.scrape "acp_service" {
-	targets    = prometheus.exporter.cloudwatch.acp_service.targets
-	job_name   = "acp_service"
-	forward_to = [prometheus.relabel.create_acp_labels.receiver]
-}
-
 // The ECS containers are resolved via CloudWatch discovery. All containers
 // resolving for the given discovery type will be scraped. All metrics are
 // forwarded to the relabelling processors as shown below.

--- a/config/003_discovery_cloudwatch.alloy
+++ b/config/003_discovery_cloudwatch.alloy
@@ -1,22 +1,3 @@
-prometheus.exporter.cloudwatch "acp_service" {
-	sts_region = sys.env("AWS_REGION")
-
-	discovery {
-		type                        = "AWS/CodePipeline"
-		regions                     = [sys.env("AWS_REGION")]
-		dimension_name_requirements = ["Pipeline"]
-		search_tags                 = {
-			"environment" = sys.env("ENVIRONMENT"),
-		}
-
-		metric {
-			name       = "PipelineDuration"
-			statistics = ["Average", "Maximum"]
-			period     = "5m"
-		}
-	}
-}
-
 prometheus.exporter.cloudwatch "ecs_service" {
 	sts_region = sys.env("AWS_REGION")
 


### PR DESCRIPTION
Reverts 0xSplits/alloy#20

Turns out `AWS/CodePipeline` is not a supported namespace within Alloy, so we cannot scrape the data I was interested in.