### PR TITLE
scrape specta containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ Alloy container.
 - `GRAFANA_CLOUD_API_KEY` - the API key of the Grafana Cloud metrics backend
 - `PROMETHEUS_REMOTE_WRITE_URL` - the URL of the Grafana Cloud metrics backend
 - `PROMETHEUS_USERNAME` - the basic auth username of the Grafana Cloud metrics backend
-- `WORKER_DISCOVERY_HOST` - the host name of the DNS discovery service for the worker component
-- `WORKER_DISCOVERY_PORT` - the port number of the worker components
 - `SERVER_DISCOVERY_HOST` - the host name of the DNS discovery service for the server component
 - `SERVER_DISCOVERY_PORT` - the port number of the server components
+- `SPECTA_DISCOVERY_HOST` - the host name of the DNS discovery service for the specta component
+- `SPECTA_DISCOVERY_HOST` - the port number of the specta components
+- `WORKER_DISCOVERY_HOST` - the host name of the DNS discovery service for the worker component
+- `WORKER_DISCOVERY_PORT` - the port number of the worker components
 
 ### Discovery
 

--- a/config/002_scrape.alloy
+++ b/config/002_scrape.alloy
@@ -22,19 +22,6 @@ prometheus.scrape "rds_instance" {
 	forward_to = [prometheus.relabel.create_rds_labels.receiver]
 }
 
-// The worker component is resolved via DNS discovery. All IP addresses
-// resolving for the given discovery host will be scraped. All metrics are
-// forwarded to the relabelling processors as shown below.
-//
-//     set_env  ->  grafana_cloud
-//
-prometheus.scrape "splits_worker" {
-	targets      = discovery.dns.worker.targets
-	metrics_path = "/metrics"
-	job_name     = "splits_worker"
-	forward_to   = [prometheus.relabel.set_env.receiver]
-}
-
 // The server component is resolved via DNS discovery. All IP addresses
 // resolving for the given discovery host will be scraped. All metrics are
 // forwarded to the relabelling processors as shown below.
@@ -45,5 +32,31 @@ prometheus.scrape "splits_server" {
 	targets      = discovery.dns.server.targets
 	metrics_path = "/metrics"
 	job_name     = "splits_server"
+	forward_to   = [prometheus.relabel.set_env.receiver]
+}
+
+// The specta component is resolved via DNS discovery. All IP addresses
+// resolving for the given discovery host will be scraped. All metrics are
+// forwarded to the relabelling processors as shown below.
+//
+//     set_env  ->  grafana_cloud
+//
+prometheus.scrape "splits_specta" {
+	targets      = discovery.dns.specta.targets
+	metrics_path = "/metrics"
+	job_name     = "splits_specta"
+	forward_to   = [prometheus.relabel.set_env.receiver]
+}
+
+// The worker component is resolved via DNS discovery. All IP addresses
+// resolving for the given discovery host will be scraped. All metrics are
+// forwarded to the relabelling processors as shown below.
+//
+//     set_env  ->  grafana_cloud
+//
+prometheus.scrape "splits_worker" {
+	targets      = discovery.dns.worker.targets
+	metrics_path = "/metrics"
+	job_name     = "splits_worker"
 	forward_to   = [prometheus.relabel.set_env.receiver]
 }

--- a/config/003_discovery_dns.alloy
+++ b/config/003_discovery_dns.alloy
@@ -1,11 +1,17 @@
-discovery.dns "worker" {
-	type  = "A"
-	names = [sys.env("WORKER_DISCOVERY_HOST")]
-	port  = sys.env("WORKER_DISCOVERY_PORT")
-}
-
 discovery.dns "server" {
 	type  = "A"
 	names = [sys.env("SERVER_DISCOVERY_HOST")]
 	port  = sys.env("SERVER_DISCOVERY_PORT")
+}
+
+discovery.dns "specta" {
+	type  = "A"
+	names = [sys.env("SPECTA_DISCOVERY_HOST")]
+	port  = sys.env("SPECTA_DISCOVERY_PORT")
+}
+
+discovery.dns "worker" {
+	type  = "A"
+	names = [sys.env("WORKER_DISCOVERY_HOST")]
+	port  = sys.env("WORKER_DISCOVERY_PORT")
 }


### PR DESCRIPTION
Here we add the DNS discovery for our new Specta service and define a scrape config so that Alloy can scrape the metrics endpoint that Specta is exposing at `/metrics`.