### PR TITLE
update docker image for alloy's base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/alloy:v1.8.3
+FROM grafana/alloy:v1.9.1
 RUN rm -rf /etc/alloy/*
 COPY config/ /etc/alloy/
 CMD ["run", "--server.http.listen-addr=0.0.0.0:12345", "/etc/alloy/"]


### PR DESCRIPTION
I just saw that there is https://github.com/grafana/alloy/releases/tag/v1.9.1 and I would like to stay up to date here.