### PR TITLE
add dependabot workflow

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,35 @@
+#
+# Do not edit. This file was generated via the "workflow" command line tool.
+# More information about the tool can be found at github.com/xh3b4sd/workflow.
+#
+#     workflow create dependabot -r xh3b4sd
+#
+
+version: 2
+updates:
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    open-pull-requests-limit: 10
+    reviewers:
+      - "xh3b4sd"
+    schedule:
+      interval: "daily"
+      time: "04:00"
+    target-branch: "main"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    open-pull-requests-limit: 10
+    reviewers:
+      - "xh3b4sd"
+    schedule:
+      interval: "daily"
+      time: "04:00"
+    target-branch: "main"


### PR DESCRIPTION
Here we add a dependabot configuration to keep Docker base images and Github Actions up to date.

For context, I am maintaining https://github.com/xh3b4sd/workflow, which I use in all kinds of repositories. This is the basis of almost all of the Github Actions that I am working with. Having a tool to create and maintain those kinds of templates all across various Github organizations and repositories helps a great deal to keep everything synchronized where tools like Dependabot cannot reach.