### PR TITLE
fix relabelling for new server containers

### DIFF
--- a/config/001_relabel.alloy
+++ b/config/001_relabel.alloy
@@ -53,14 +53,6 @@ prometheus.relabel "create_ecs_labels" {
 	rule {
 		action        = "replace"
 		source_labels = ["dimension_ServiceName"]
-		regex         = ".*"
-		replacement   = "server"
-		target_label  = "service"
-	}
-
-	rule {
-		action        = "replace"
-		source_labels = ["dimension_ServiceName"]
 		regex         = ".*-alloy$"
 		replacement   = "alloy"
 		target_label  = "service"
@@ -79,6 +71,22 @@ prometheus.relabel "create_ecs_labels" {
 		source_labels = ["dimension_ServiceName"]
 		regex         = ".*otel-collector.*"
 		replacement   = "otel-collector"
+		target_label  = "service"
+	}
+
+	rule {
+		action        = "replace"
+		source_labels = ["dimension_ServiceName"]
+		regex         = ".*-server$"
+		replacement   = "server"
+		target_label  = "service"
+	}
+
+	rule {
+		action        = "replace"
+		source_labels = ["dimension_ServiceName"]
+		regex         = ".*-specta$"
+		replacement   = "specta"
 		target_label  = "service"
 	}
 

--- a/recording_rules/slo_frontend_usability.md
+++ b/recording_rules/slo_frontend_usability.md
@@ -1,0 +1,41 @@
+```yaml
+# Calculate the SLO for the teams frontend in all environments. The basis of the
+# SLO is 1. The error budget taking away from the SLO is represented by pages
+# that take too long to become ready for the user. We multiply the resulting
+# ratio by 100, because the SLO is represented as percent. Note that we
+# aggregate 1 hour queries, instead of 5 minute queries, because we are working
+# with rather sparse data here at the moment.
+#
+#     100 * ( 1 - latency SLO )
+#
+#     https://www.notion.so/splits/Service-Level-Objectives-208f7c3c8eff80bf9efcf1b1b9d4b105?source=copy_link#208f7c3c8eff8096af5efe11b5d682df
+#
+100 * (
+    1
+
+    -
+
+    # Calculate the average ratio of slow pages, over a 24 hour rolling
+    # window. The resulting error ratio is taking away from the SLO basis above.
+    #
+    #     all latencies - 500ms latencies
+    #     -------------------------------
+    #              all latencies
+    #
+    avg_over_time(
+        (
+            (
+                sum by (env) (rate(page_ready_duration_seconds_bucket{page="root", le="+Inf"}[1h]))
+                -
+                sum by (env) (rate(page_ready_duration_seconds_bucket{page="root", le="0.5"}[1h]))
+            )
+
+            /
+
+            (
+                sum by (env) (rate(page_ready_duration_seconds_bucket{page="root", le="+Inf"}[1h]))
+            )
+        )[1d:]
+    )
+)
+```


### PR DESCRIPTION
Towards https://linear.app/splits/issue/PE-4440/fix-relabelling-in-alloy-to-account-for-the-new-specta-ecs-service. 

Since we migrated the server containers to their separate CloudFormation stacks, the labeling changed a little bit so that we have to adjust the relabeling pipeline that we were running so far. Here we fixed the relabeling and make sure that only the new server containers are labeled properly for their respective metrics.

I think what happened meanwhile was that the Specta containers were also labeled as `server` metrics, causing the `Server / Service` dashboard in Grafana to show more CPU utilization and memory utilization metrics than there are actually server containers. I'm not really sure how to test this change, other than deploying it to the testing environment, so I got to go ahead and merge this.