### PR TITLE
PE-7055: remove Pulsar scrape/discovery from Alloy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ Alloy container.
 - `PROMETHEUS_USERNAME` - the basic auth username of the Grafana Cloud metrics backend
 - `KAYRON_DISCOVERY_HOST` - the host name of the DNS discovery service for the kayron component
 - `KAYRON_DISCOVERY_HOST` - the port number of the kayron components
-- `PULSAR_DISCOVERY_HOST` - the host name of the DNS discovery service for the pulsar component
-- `PULSAR_DISCOVERY_HOST` - the port number of the pulsar components
 - `SERVER_DISCOVERY_HOST` - the host name of the DNS discovery service for the server component
 - `SERVER_DISCOVERY_PORT` - the port number of the server components
 - `SPECTA_DISCOVERY_HOST` - the host name of the DNS discovery service for the specta component

--- a/config/001_relabel.alloy
+++ b/config/001_relabel.alloy
@@ -77,14 +77,6 @@ prometheus.relabel "create_ecs_labels" {
 	rule {
 		action        = "replace"
 		source_labels = ["dimension_ServiceName"]
-		regex         = ".*-pulsar$"
-		replacement   = "pulsar"
-		target_label  = "service"
-	}
-
-	rule {
-		action        = "replace"
-		source_labels = ["dimension_ServiceName"]
 		regex         = ".*-graphql$"
 		replacement   = "graphql"
 		target_label  = "service"

--- a/config/002_scrape.alloy
+++ b/config/002_scrape.alloy
@@ -35,19 +35,6 @@ prometheus.scrape "splits_kayron" {
 	forward_to   = [prometheus.relabel.set_env.receiver]
 }
 
-// The pulsar component is resolved via DNS discovery. All IP addresses
-// resolving for the given discovery host will be scraped. All metrics are
-// forwarded to the relabelling processors as shown below.
-//
-//     set_env  ->  grafana_cloud
-//
-prometheus.scrape "splits_pulsar" {
-	targets      = discovery.dns.pulsar.targets
-	metrics_path = "/metrics"
-	job_name     = "splits_pulsar"
-	forward_to   = [prometheus.relabel.set_env.receiver]
-}
-
 // The server component is resolved via DNS discovery. All IP addresses
 // resolving for the given discovery host will be scraped. All metrics are
 // forwarded to the relabelling processors as shown below.

--- a/config/003_discovery_dns.alloy
+++ b/config/003_discovery_dns.alloy
@@ -4,12 +4,6 @@ discovery.dns "kayron" {
 	port  = sys.env("KAYRON_DISCOVERY_PORT")
 }
 
-discovery.dns "pulsar" {
-	type  = "A"
-	names = [sys.env("PULSAR_DISCOVERY_HOST")]
-	port  = sys.env("PULSAR_DISCOVERY_PORT")
-}
-
 discovery.dns "server" {
 	type  = "A"
 	names = [sys.env("SERVER_DISCOVERY_HOST")]


### PR DESCRIPTION
## Summary

Pulsar (real-time transaction indexing) is being decommissioned, so Alloy should stop discovering and scraping it:

- `config/002_scrape.alloy` — remove the `splits_pulsar` `prometheus.scrape` block
- `config/003_discovery_dns.alloy` — remove the `discovery.dns "pulsar"` block
- `config/001_relabel.alloy` — remove the `.*-pulsar$` `ServiceName` relabel rule
- `README.md` — drop the `PULSAR_DISCOVERY_HOST` env var docs

Companion to 0xSplits/infrastructure#68 (which also stops passing `PULSAR_DISCOVERY_HOST`/`PULSAR_DISCOVERY_PORT` to the Alloy container) and 0xSplits/specta#131.

Linear: PE-7055

🤖 Generated with [Claude Code](https://claude.com/claude-code)