### PR TITLE
scrape indexing service metrics

### DIFF
--- a/config/002_scrape.alloy
+++ b/config/002_scrape.alloy
@@ -22,6 +22,19 @@ prometheus.scrape "rds_instance" {
 	forward_to = [prometheus.relabel.create_rds_labels.receiver]
 }
 
+// The indexing component is resolved via DNS discovery. All IP addresses
+// resolving for the given discovery host will be scraped. All metrics are
+// forwarded to the relabelling processors as shown below.
+//
+//     set_env  ->  grafana_cloud
+//
+prometheus.scrape "splits_indexing" {
+	targets      = discovery.dns.indexing.targets
+	metrics_path = "/metrics"
+	job_name     = "splits_indexing"
+	forward_to   = [prometheus.relabel.set_env.receiver]
+}
+
 // The kayron component is resolved via DNS discovery. All IP addresses
 // resolving for the given discovery host will be scraped. All metrics are
 // forwarded to the relabelling processors as shown below.

--- a/config/003_discovery_dns.alloy
+++ b/config/003_discovery_dns.alloy
@@ -1,3 +1,9 @@
+discovery.dns "indexing" {
+	type  = "A"
+	names = [sys.env("INDEXING_DISCOVERY_HOST")]
+	port  = sys.env("INDEXING_DISCOVERY_PORT")
+}
+
 discovery.dns "kayron" {
 	type  = "A"
 	names = [sys.env("KAYRON_DISCOVERY_HOST")]


### PR DESCRIPTION
Adds DNS discovery and Prometheus scrape config for the new `indexing` ECS service so its `/metrics` endpoint is shipped to Grafana Cloud.

- `config/003_discovery_dns.alloy`: `discovery.dns "indexing"` driven by `INDEXING_DISCOVERY_HOST` / `INDEXING_DISCOVERY_PORT`
- `config/002_scrape.alloy`: `prometheus.scrape "splits_indexing"` targeting the new discovery block

Depends on infrastructure changes already merged (v0.5.1) that set the `INDEXING_DISCOVERY_*` env vars on the Alloy container.