### PR TITLE
PE-7693 | Add ElastiCache/Redis metrics via Alloy + Redis dashboard

### DIFF
--- a/.github/workflows/alloy-check.yaml
+++ b/.github/workflows/alloy-check.yaml
@@ -1,0 +1,69 @@
+name: "Alloy Check"
+
+on:
+  # Gate every pull request so unformatted or invalid config never reaches main.
+  pull_request:
+  # Also run on direct pushes to main as a backstop.
+  push:
+    branches:
+      - "main"
+
+jobs:
+  alloy-check:
+    permissions:
+      contents: "read"
+
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4.2.2"
+
+      # Pin the toolchain to the exact Alloy version baked into the Docker image
+      # so CI checks the config against the same binary that runs in production.
+      # Reading it from the Dockerfile avoids the two drifting apart.
+      - name: "Resolve Alloy Version"
+        id: "alloy"
+        run: |
+          version="$(grep -Eo 'grafana/alloy:[^ ]+' Dockerfile | cut -d: -f2)"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      # alloy fmt operates on a single file, so we iterate. The -t flag makes fmt
+      # exit non-zero when a file is not formatted correctly without writing any
+      # changes, which is exactly what we want for a check.
+      - name: "Check Formatting"
+        run: |
+          docker run --rm --entrypoint sh \
+            -v "${PWD}/config:/config" \
+            "grafana/alloy:${{ steps.alloy.outputs.version }}" -c '
+              rc=0
+              for f in $(find /config -name "*.alloy"); do
+                if ! alloy fmt -t "$f"; then
+                  echo "not formatted: $f (run: alloy fmt -w $f)"
+                  rc=1
+                fi
+              done
+              exit $rc
+            '
+
+      # Validate the whole config directory at once, since the processor pipeline
+      # references components across files. The env vars below are dummy values
+      # that only need to be present for sys.env() references to resolve; validate
+      # checks config structure and does not connect to any of these endpoints.
+      - name: "Validate Configuration"
+        run: |
+          docker run --rm \
+            -v "${PWD}/config:/config" \
+            -e AWS_REGION="us-west-2" \
+            -e ENVIRONMENT="ci" \
+            -e GRAFANA_CLOUD_API_KEY="ci" \
+            -e PROMETHEUS_REMOTE_WRITE_URL="https://example.com" \
+            -e PROMETHEUS_USERNAME="ci" \
+            -e KAYRON_DISCOVERY_HOST="kayron" \
+            -e KAYRON_DISCOVERY_PORT="8080" \
+            -e SERVER_DISCOVERY_HOST="server" \
+            -e SERVER_DISCOVERY_PORT="8080" \
+            -e SPECTA_DISCOVERY_HOST="specta" \
+            -e SPECTA_DISCOVERY_PORT="8080" \
+            -e WORKER_DISCOVERY_HOST="worker" \
+            -e WORKER_DISCOVERY_PORT="8080" \
+            "grafana/alloy:${{ steps.alloy.outputs.version }}" validate /config

--- a/.github/workflows/alloy-check.yaml
+++ b/.github/workflows/alloy-check.yaml
@@ -27,43 +27,48 @@ jobs:
           version="$(grep -Eo 'grafana/alloy:[^ ]+' Dockerfile | cut -d: -f2)"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
+      - name: "Install Alloy"
+        run: |
+          version="${{ steps.alloy.outputs.version }}"
+          curl -fsSL -o alloy.zip \
+            "https://github.com/grafana/alloy/releases/download/${version}/alloy-linux-amd64.zip"
+          unzip -q alloy.zip
+          binary="$(find . -maxdepth 1 -type f -name 'alloy-linux-amd64*' | head -n1)"
+          sudo install -m 0755 "${binary}" /usr/local/bin/alloy
+          rm -f alloy.zip "${binary}"
+          alloy --version
+
       # alloy fmt operates on a single file, so we iterate. The -t flag makes fmt
       # exit non-zero when a file is not formatted correctly without writing any
       # changes, which is exactly what we want for a check.
       - name: "Check Formatting"
         run: |
-          docker run --rm --entrypoint sh \
-            -v "${PWD}/config:/config" \
-            "grafana/alloy:${{ steps.alloy.outputs.version }}" -c '
-              rc=0
-              for f in $(find /config -name "*.alloy"); do
-                if ! alloy fmt -t "$f"; then
-                  echo "not formatted: $f (run: alloy fmt -w $f)"
-                  rc=1
-                fi
-              done
-              exit $rc
-            '
+          rc=0
+          while IFS= read -r f; do
+            if ! alloy fmt -t "$f"; then
+              echo "not formatted: $f (fix with: alloy fmt -w $f)"
+              rc=1
+            fi
+          done < <(find config -type f -name '*.alloy')
+          exit $rc
 
       # Validate the whole config directory at once, since the processor pipeline
       # references components across files. The env vars below are dummy values
       # that only need to be present for sys.env() references to resolve; validate
       # checks config structure and does not connect to any of these endpoints.
       - name: "Validate Configuration"
-        run: |
-          docker run --rm \
-            -v "${PWD}/config:/config" \
-            -e AWS_REGION="us-west-2" \
-            -e ENVIRONMENT="ci" \
-            -e GRAFANA_CLOUD_API_KEY="ci" \
-            -e PROMETHEUS_REMOTE_WRITE_URL="https://example.com" \
-            -e PROMETHEUS_USERNAME="ci" \
-            -e KAYRON_DISCOVERY_HOST="kayron" \
-            -e KAYRON_DISCOVERY_PORT="8080" \
-            -e SERVER_DISCOVERY_HOST="server" \
-            -e SERVER_DISCOVERY_PORT="8080" \
-            -e SPECTA_DISCOVERY_HOST="specta" \
-            -e SPECTA_DISCOVERY_PORT="8080" \
-            -e WORKER_DISCOVERY_HOST="worker" \
-            -e WORKER_DISCOVERY_PORT="8080" \
-            "grafana/alloy:${{ steps.alloy.outputs.version }}" validate /config
+        env:
+          AWS_REGION: "us-west-2"
+          ENVIRONMENT: "ci"
+          GRAFANA_CLOUD_API_KEY: "ci"
+          PROMETHEUS_REMOTE_WRITE_URL: "https://example.com"
+          PROMETHEUS_USERNAME: "ci"
+          KAYRON_DISCOVERY_HOST: "kayron"
+          KAYRON_DISCOVERY_PORT: "8080"
+          SERVER_DISCOVERY_HOST: "server"
+          SERVER_DISCOVERY_PORT: "8080"
+          SPECTA_DISCOVERY_HOST: "specta"
+          SPECTA_DISCOVERY_PORT: "8080"
+          WORKER_DISCOVERY_HOST: "worker"
+          WORKER_DISCOVERY_PORT: "8080"
+        run: alloy validate config/

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Alloy container.
 ### Discovery
 
 We are using the [CloudWatch Exporter] for metrics discovery of managed AWS
-services like ECS containers and RDS instances. Note that it is best practice to
+services like ECS containers, RDS instances, and ElastiCache (Redis) clusters.
+Note that it is best practice to
 filter for AWS resource tags, e.g. `environment`, so that we can process metrics
 for the environment that those metrics are associated with. Also note that this
 requires the respective AWS resources to be tagged accordingly. Using the AWS

--- a/config/001_relabel.alloy
+++ b/config/001_relabel.alloy
@@ -124,3 +124,22 @@ prometheus.relabel "create_rds_labels" {
 
 	forward_to = [prometheus.relabel.delete_cloudwatch_labels.receiver]
 }
+
+// Create labels based on ElastiCache dimensions to make it easier for certain
+// dashboard queries. Like RDS, there is only one logical Redis cluster per
+// environment backing the server, so we apply a single service label. The
+// per-node identity (primary vs replica) is preserved via the
+// dimension_CacheClusterId label that the CloudWatch exporter emits, so the
+// dashboard can break the two nodes apart without us baking a static role label
+// that would become wrong after a failover.
+prometheus.relabel "create_elasticache_labels" {
+	rule {
+		action        = "replace"
+		source_labels = ["dimension_CacheClusterId"]
+		regex         = ".*"
+		replacement   = "server"
+		target_label  = "service"
+	}
+
+	forward_to = [prometheus.relabel.delete_cloudwatch_labels.receiver]
+}

--- a/config/002_scrape.alloy
+++ b/config/002_scrape.alloy
@@ -22,6 +22,18 @@ prometheus.scrape "rds_instance" {
 	forward_to = [prometheus.relabel.create_rds_labels.receiver]
 }
 
+// The ElastiCache nodes are resolved via CloudWatch discovery. All cache
+// clusters resolving for the given discovery type will be scraped. All metrics
+// are forwarded to the relabelling processors as shown below.
+//
+//     create_elasticache_labels  ->  delete_cloudwatch_labels  ->  set_env  ->  grafana_cloud
+//
+prometheus.scrape "elasticache" {
+	targets    = prometheus.exporter.cloudwatch.elasticache.targets
+	job_name   = "elasticache"
+	forward_to = [prometheus.relabel.create_elasticache_labels.receiver]
+}
+
 // The indexing component is resolved via DNS discovery. All IP addresses
 // resolving for the given discovery host will be scraped. All metrics are
 // forwarded to the relabelling processors as shown below.

--- a/config/003_discovery_cloudwatch.alloy
+++ b/config/003_discovery_cloudwatch.alloy
@@ -83,3 +83,77 @@ prometheus.exporter.cloudwatch "rds_instance" {
 		}
 	}
 }
+
+prometheus.exporter.cloudwatch "elasticache" {
+	sts_region = sys.env("AWS_REGION")
+
+	discovery {
+		type                        = "AWS/ElastiCache"
+		regions                     = [sys.env("AWS_REGION")]
+		dimension_name_requirements = ["CacheClusterId"]
+		search_tags                 = {
+			"environment" = sys.env("ENVIRONMENT"),
+		}
+
+		// Gauges. We track the average and maximum to surface both steady state
+		// and short lived spikes that can drive failovers or evictions.
+
+		metric {
+			name       = "DatabaseMemoryUsagePercentage"
+			statistics = ["Average", "Maximum"]
+			period     = "5m"
+		}
+
+		metric {
+			name       = "FreeableMemory"
+			statistics = ["Average", "Maximum"]
+			period     = "5m"
+		}
+
+		metric {
+			name       = "EngineCPUUtilization"
+			statistics = ["Average", "Maximum"]
+			period     = "5m"
+		}
+
+		metric {
+			name       = "CurrConnections"
+			statistics = ["Average", "Maximum"]
+			period     = "5m"
+		}
+
+		metric {
+			name       = "SwapUsage"
+			statistics = ["Average", "Maximum"]
+			period     = "5m"
+		}
+
+		metric {
+			name       = "ReplicationLag"
+			statistics = ["Average", "Maximum"]
+			period     = "5m"
+		}
+
+		// Counters. CloudWatch reports these as a sum over the period, so we must
+		// scrape the Sum statistic for the hit rate and eviction panels to be
+		// accurate. Scraping Average here would understate the real volume.
+
+		metric {
+			name       = "CacheHits"
+			statistics = ["Sum"]
+			period     = "5m"
+		}
+
+		metric {
+			name       = "CacheMisses"
+			statistics = ["Sum"]
+			period     = "5m"
+		}
+
+		metric {
+			name       = "Evictions"
+			statistics = ["Sum"]
+			period     = "5m"
+		}
+	}
+}

--- a/dashboards/server/redis.json
+++ b/dashboards/server/redis.json
@@ -906,6 +906,6 @@
   "timepicker": {},
   "timezone": "browser",
   "title": "Redis",
-  "uid": "a1b2c3d4-redis-server-cache-0001",
+  "uid": "7e5392c5-d5d0-4053-bf0c-9109ae15bcfa",
   "version": 1
 }

--- a/dashboards/server/redis.json
+++ b/dashboards/server/redis.json
@@ -1,0 +1,911 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88106",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "aws_elasticache_database_memory_usage_percentage_average{env=\"$env\", service=\"server\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{dimension_CacheClusterId}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "aws_elasticache_database_memory_usage_percentage_maximum{env=\"$env\", service=\"server\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{dimension_CacheClusterId}} (max)",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Database Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88106",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "aws_elasticache_freeable_memory_average{env=\"$env\", service=\"server\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{dimension_CacheClusterId}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Freeable Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88106",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "aws_elasticache_engine_cpuutilization_average{env=\"$env\", service=\"server\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{dimension_CacheClusterId}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "aws_elasticache_engine_cpuutilization_maximum{env=\"$env\", service=\"server\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{dimension_CacheClusterId}} (max)",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Engine CPU Utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88106",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "aws_elasticache_curr_connections_average{env=\"$env\", service=\"server\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{dimension_CacheClusterId}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Current Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88106",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum(aws_elasticache_cache_hits_sum{env=\"$env\", service=\"server\"}) / (sum(aws_elasticache_cache_hits_sum{env=\"$env\", service=\"server\"}) + sum(aws_elasticache_cache_misses_sum{env=\"$env\", service=\"server\"}))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "hit rate",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Cache Hit Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88106",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum(aws_elasticache_evictions_sum{env=\"$env\", service=\"server\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "evictions",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Evictions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88106",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "aws_elasticache_swap_usage_average{env=\"$env\", service=\"server\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{dimension_CacheClusterId}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Swap Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-88106",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "aws_elasticache_replication_lag_average{env=\"$env\", service=\"server\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{dimension_CacheClusterId}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Replication Lag",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "production",
+          "value": "production"
+        },
+        "definition": "label_values(env)",
+        "label": "environment",
+        "name": "env",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(env)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/^(?!dev$|beta$).*/",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Redis",
+  "uid": "a1b2c3d4-redis-server-cache-0001",
+  "version": 1
+}


### PR DESCRIPTION
## Why

We had no visibility into our Redis (ElastiCache) clusters — there were zero `aws_elasticache_*` metrics in Grafana, so memory pressure, evictions, or a lagging replica were effectively invisible until something broke. This PR closes that gap.

## What you get

- **Redis metrics in Grafana.** Alloy now scrapes the key ElastiCache health signals from CloudWatch (memory usage, freeable memory, engine CPU, connections, cache hit rate, evictions, swap, replication lag), following the same pattern we already use for ECS and RDS.
- **A ready-made Redis dashboard** (`dashboards/server/redis.json`) — 8 panels, broken out per node (primary vs. replica) so on-call can spot an unhealthy node at a glance.
- **A CI safety net.** A new "Alloy Check" workflow runs `alloy fmt` and `alloy validate` on every PR. Previously formatting was manual and nothing validated the config before it reached a running container — now a malformed or invalid config can't merge.

## Rollout (action required)

Config is baked into the Docker image, so **metrics only start flowing after merge**: cut a release `vX.Y.Z-<sha>`, then redeploy Alloy across all environments. Redis alerting intentionally stays in CloudWatch for now — there are no alerting changes here.

## How it was verified

- Confirmed the ElastiCache replication groups in `us-west-2` (production / staging / testing) are tagged `environment` and expose every scraped metric at per-node granularity.
- `alloy fmt` and `alloy validate` pass in CI against the prod-pinned Alloy `v1.13.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
